### PR TITLE
Make text to XML conversion faster.

### DIFF
--- a/fsc_cryosparc2_to_emdb-xml.sh
+++ b/fsc_cryosparc2_to_emdb-xml.sh
@@ -81,22 +81,20 @@ cat $IN | awk -v BOX=$BOX -v APIX=$APIX -v COL=$COL '{if(NR>1) print ($1/(BOX * 
 
 ###now convert this file to xml format
 
-i=1
-
-j=`cat ${IN%*.txt}_${TYPE}.txt | wc -l`
-j=$(( j + 1 ))
-
 echo '<fsc title="" xaxis="Resolution (A-1)" yaxis="Correlation Coefficient">' >  $XMLOUT
 
-while [ $i -lt $j ]
+HEADER=1
+cat ${TXTOUT} | while read X Y
 do
-	x=`cat $TXTOUT | awk -v i=$i '{if(NR==i) print $1}'`
-	y=`cat $TXTOUT | awk -v i=$i '{if(NR==i) print $2}'`
+	if [ "$HEADER" ]
+	then
+		HEADER=
+		continue
+	fi
 	echo '  <coordinate>' >> $XMLOUT
-	echo "    <x>$x</x>" >> $XMLOUT
-	echo "    <y>$y</y>" >> $XMLOUT
+	echo "    <x>$X</x>" >> $XMLOUT
+	echo "    <y>$Y</y>" >> $XMLOUT
 	echo '  </coordinate>' >> $XMLOUT
-	i=$(( i + 1 ))
 done
 
 echo '</fsc>' >> $XMLOUT


### PR DESCRIPTION
This fixes code that runs in quadratic time (since to read each line of the text file it starts from the beginning) to run in linear time by doing only a single read of the text file to convert it to XML.

This makes conversion of a ~1500 line file instantaneous rather than slow enough that I didn't wait for it to finish.

I admit I only tested part of the script rather than the whole script, since I was just using it for the text to XML part.  My wife found it while looking for what the desired XML format was, and wanted to use it for just the text-to-XML part.  So what I was actually testing was an edited version of the script designed to do just that part; I think I've put the modifications back into the original correctly, but I'm not 100% sure, and it could use testing.